### PR TITLE
fix: if the 'transfers' node is empty then it is not transfer

### DIFF
--- a/src/xml.ts
+++ b/src/xml.ts
@@ -78,12 +78,12 @@ export default class XML {
       parseString(xml, function (err, result) {
         let isTransfer = false;
         if (result.electronicDocument.transfers) {
-          isTransfer = true;
           const lastNodeTransfer =
             result.electronicDocument.transfers[
               result.electronicDocument.transfers.length - 1
             ];
           if (lastNodeTransfer?.electronicDocument) {
+            isTransfer = true;
             result.originalElectronicDocument = result.electronicDocument;
             result.electronicDocument =
               lastNodeTransfer.electronicDocument[


### PR DESCRIPTION
Este cambio no afecta el funcionamiento actual, es decir, ya se hicieron pruebas y funciona todo perfectamente sin embargo me di cuenta que si tiene el nodo transfers y no tiene contenido, entonces la bandera de isTransfer debe estar en false