### PR TITLE
fix: just get the blockchain data in the parent xml

### DIFF
--- a/src/document.ts
+++ b/src/document.ts
@@ -365,6 +365,7 @@ export default class Document {
     xml,
     prevHolder = null,
     useTestnet = false,
+    isOriginalDocument = false,
   }) => {
     const parseStringToBoolean = (string) => string === "true";
 
@@ -387,7 +388,7 @@ export default class Document {
       network: null,
     };
 
-    if (xml.tracked) {
+    if (xml.tracked && isOriginalDocument) {
       const assetId = xml.eDocument.blockchain[0].asset[0].$.id;
       const network = xml.eDocument.blockchain[0].$.name;
 
@@ -418,6 +419,7 @@ export default class Document {
           const opts = await this.getOptsToInitializeDocument({
             xml,
             useTestnet,
+            isOriginalDocument: true
           });
           const doc = new Document(xml.file(), opts);
           resolve({
@@ -427,7 +429,6 @@ export default class Document {
             xmlHash:
               xml.getConservancyRecord() &&
               xml.getConservancyRecord().originalXmlHash,
-            // hash as attribute in the xml
             xmlOriginalHash: xml.originalHash,
           });
         })


### PR DESCRIPTION
Lo que estaba sucediendo es que para que sea tracked un documento basta con que exista el nodo blockchain pero este se repite en cada trasnfer por que al final de cuentas es un xml completo, lo que hago aquí es identificar al padre y solo hacer la consulta a la blockchain en ese caso
