### PR TITLE
fix: send the correct parameters in the date parsing function #86du3xvyx

### DIFF
--- a/src/certificate.ts
+++ b/src/certificate.ts
@@ -4,7 +4,7 @@ import { hextoAscii } from './common';
 const parseDate = function(certDate) {
   const parsed = certDate.match(/(\d{2})(\d{2})(\d{2})(\d{2})(\d{2})(\d{2})Z/);
   parsed.shift(1);
-  return new Date(Date.UTC(2000 + parseInt(parsed[0]), parsed[1], parsed[2], parsed[3], parsed[4], parsed[5]));
+  return new Date(Date.UTC(2000 + parseInt(parsed[0]), parseInt(parsed[1]) - 1, parsed[2], parsed[3], parsed[4], parsed[5]));
 };
 
 const jsrsasign = require('jsrsasign');


### PR DESCRIPTION
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/UTC

Segun la doc en el campo de meses se pone el indice del mes, por eso siempre tenemos 1 mes adelantado