### PR TITLE
Cu 86e0pzc96 xml fiesta js

### DIFF
--- a/src/xml.ts
+++ b/src/xml.ts
@@ -91,7 +91,7 @@ export default class XML {
   static detectNamespacePrefix(xmlString: string): string | null {
     // Find the prefix used in the electronicDocument element
     const prefixMatch = xmlString.match(
-      /<\s*([A-Za-z_][\w.-]*):electronicDocument\b/
+      /<\s*([A-Za-z_][\w.-]*):electronicDocument\b/,
     );
     return prefixMatch ? prefixMatch[1] : null;
   }
@@ -161,24 +161,13 @@ export default class XML {
           // Remove only the xmlns:<detectedPrefix> declarations after parsing
           el.parseByElectronicDocument(electronicDocument);
           return resolve(el);
-        }
-      )
+        },
+      ),
     );
   }
 
-  canonical(electronicDocumentAttributes = {}) {
+  canonical() {
     let edoc = JSON.parse(JSON.stringify(this.eDocument));
-
-    if (
-      electronicDocumentAttributes &&
-      Object.keys(electronicDocumentAttributes).length
-    ) {
-      Object.entries(electronicDocumentAttributes).map(([key, value]) => {
-        if (key.includes("xmlns")) {
-          edoc.$[key] = value;
-        }
-      });
-    }
 
     delete edoc.$.cancel;
     delete edoc.conservancyRecord;
@@ -214,8 +203,8 @@ export default class XML {
     return canonicalString.replace(/&#xD;/g, "");
   }
 
-  getCanonicalBuffer(electronicDocumentAttributes) {
-    return Buffer.from(this.canonical(electronicDocumentAttributes), "utf-8");
+  getCanonicalBuffer() {
+    return Buffer.from(this.canonical(), "utf-8");
   }
 
   file() {

--- a/yarn.lock
+++ b/yarn.lock
@@ -397,12 +397,12 @@
   dependencies:
     undici-types "~7.16.0"
 
-"@types/node@25.5.0":
-  version "25.5.0"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-25.5.0.tgz#5c99f37c443d9ccc4985866913f1ed364217da31"
-  integrity sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw==
+"@types/node@^18.0":
+  version "18.19.130"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-18.19.130.tgz#da4c6324793a79defb7a62cba3947ec5add00d59"
+  integrity sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==
   dependencies:
-    undici-types "~7.18.0"
+    undici-types "~5.26.4"
 
 "@types/xml2js@0.4.14":
   version "0.4.14"
@@ -1648,15 +1648,15 @@ ufo@^1.6.3:
   resolved "https://registry.yarnpkg.com/ufo/-/ufo-1.6.3.tgz#799666e4e88c122a9659805e30b9dc071c3aed4f"
   integrity sha512-yDJTmhydvl5lJzBmy/hyOAA0d+aqCBuwl818haVdYCRrWV84o7YyeVm4QlVHStqNrrJSTb6jKuFAVqAFsr+K3Q==
 
+undici-types@~5.26.4:
+  version "5.26.5"
+  resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-5.26.5.tgz#bcd539893d00b56e964fd2657a4866b221a65617"
+  integrity sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==
+
 undici-types@~7.16.0:
   version "7.16.0"
   resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-7.16.0.tgz#ffccdff36aea4884cbfce9a750a0580224f58a46"
   integrity sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==
-
-undici-types@~7.18.0:
-  version "7.18.2"
-  resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-7.18.2.tgz#29357a89e7b7ca4aef3bf0fd3fd0cd73884229e9"
-  integrity sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==
 
 update-browserslist-db@^1.2.3:
   version "1.2.3"


### PR DESCRIPTION
Por alguna razón esto ya debia funcionar sin solicitar los parametros, entonces solo remuevo esta logica extra pero ya debe funcionar , lo quité y validé el resultado del xml canonico que sea igual que en qa

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified XML canonicalization API by removing optional parameters from related methods, reducing configuration complexity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->